### PR TITLE
サイドバーのトグルアイコンを鉛筆アイコンに変更

### DIFF
--- a/components/sidebar-toggle.tsx
+++ b/components/sidebar-toggle.tsx
@@ -7,7 +7,7 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip';
 
-import { SidebarLeftIcon } from './icons';
+import { PencilEditIcon } from './icons';
 import { Button } from './ui/button';
 
 export function SidebarToggle({
@@ -23,7 +23,7 @@ export function SidebarToggle({
           variant="outline"
           className="md:px-2 md:h-fit"
         >
-          <SidebarLeftIcon size={16} />
+          <PencilEditIcon size={16} />
         </Button>
       </TooltipTrigger>
       <TooltipContent align="start">Toggle Sidebar</TooltipContent>

--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -20,6 +20,7 @@ import {
 } from '@/components/ui/tooltip';
 import { useRouter } from 'next/navigation';
 import { createClient } from '@/utils/supabase/client';
+import { PencilEditIcon } from '@/components/icons';
 
 const SIDEBAR_COOKIE_NAME = 'sidebar:state';
 const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;
@@ -327,7 +328,7 @@ const SidebarTrigger = React.forwardRef<
       }}
       {...props}
     >
-      <PanelLeft />
+      <PencilEditIcon />
       <span className="sr-only">Toggle Sidebar</span>
     </Button>
   );


### PR DESCRIPTION
## 変更内容
- サイドバーのトグルアイコンを鉛筆アイコンに変更
  - `components/ui/sidebar.tsx`の`SidebarTrigger`コンポーネントのアイコンを`PanelLeft`から`PencilEditIcon`に変更
  - `components/sidebar-toggle.tsx`の`SidebarToggle`コンポーネントのアイコンを`SidebarLeftIcon`から`PencilEditIcon`に変更

## 確認事項
- サイドバーのトグルボタンに鉛筆アイコンが表示されていることを確認
- サイドバーの開閉機能が正常に動作することを確認